### PR TITLE
High Sierra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Created by https://www.gitignore.io/api/swift,osx
 ## Build generated
 build/
 DerivedData/
+Index/
 
 ## Various settings
 *.pbxuser

--- a/Domain/Domain.swift
+++ b/Domain/Domain.swift
@@ -1,0 +1,12 @@
+//
+//  Domain.swift
+//  Domain
+//
+//  Created by Ihara Takeshi on 2017/11/18.
+//
+
+import Foundation
+
+class Domain {
+
+}

--- a/Infrastructure/Infrastructure.swift
+++ b/Infrastructure/Infrastructure.swift
@@ -1,0 +1,12 @@
+//
+//  Infrastructure.swift
+//  Infrastructure
+//
+//  Created by Ihara Takeshi on 2017/11/18.
+//
+
+import Foundation
+
+class Infrastructure {
+
+}


### PR DESCRIPTION
Compile Sourcesが空だとmodulemapが生成できない問題を解消